### PR TITLE
Add undirected-graph support

### DIFF
--- a/grandiso/test_grandiso.py
+++ b/grandiso/test_grandiso.py
@@ -1,7 +1,7 @@
 import unittest
 
 import networkx as nx
-from networkx.algorithms.isomorphism import DiGraphMatcher
+from networkx.algorithms.isomorphism import DiGraphMatcher, GraphMatcher
 
 from . import find_motifs
 
@@ -107,4 +107,108 @@ class TestSubgraphMatching(unittest.TestCase):
         self.assertEqual(
             len(find_motifs(motif, host)),
             len([i for i in DiGraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
+        )
+
+
+class TestUndirectedSubgraphMatching(unittest.TestCase):
+    def test_subgraph_equals_graph_triangle(self):
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("B", "C")
+        motif.add_edge("C", "A")
+
+        host = nx.Graph()
+        host.add_edge("A", "B")
+        host.add_edge("B", "C")
+        host.add_edge("C", "A")
+
+        self.assertEqual(len(find_motifs(motif, host)), 6)
+
+    def test_subgraph_equals_graph_rect(self):
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("B", "C")
+        motif.add_edge("C", "D")
+        motif.add_edge("D", "A")
+
+        host = nx.Graph()
+        host.add_edge("A", "B")
+        host.add_edge("B", "C")
+        host.add_edge("C", "D")
+        host.add_edge("D", "A")
+
+        self.assertEqual(len(find_motifs(motif, host)), 8)
+
+    def test_rect_count_matches_nx(self):
+
+        host = nx.fast_gnp_random_graph(10, 0.5, directed=False)
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("B", "C")
+        motif.add_edge("C", "D")
+        motif.add_edge("D", "A")
+
+        self.assertEqual(
+            len(find_motifs(motif, host)),
+            len([i for i in GraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
+        )
+
+    def test_tri_count_matches_nx(self):
+
+        host = nx.fast_gnp_random_graph(10, 0.5, directed=False)
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("B", "C")
+        motif.add_edge("C", "A")
+
+        self.assertEqual(
+            len(find_motifs(motif, host)),
+            len([i for i in GraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
+        )
+
+    def test_two_hop_count_matches_nx(self):
+
+        host = nx.fast_gnp_random_graph(10, 0.5, directed=False)
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("B", "C")
+
+        self.assertEqual(
+            len(find_motifs(motif, host)),
+            len([i for i in GraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
+        )
+
+    def test_high_degree_high_density_count_matches_nx(self):
+
+        host = nx.fast_gnp_random_graph(10, 1, directed=False)
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("A", "C")
+        motif.add_edge("A", "D")
+        motif.add_edge("A", "E")
+
+        self.assertEqual(
+            len(find_motifs(motif, host)),
+            len([i for i in GraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
+        )
+
+    def test_high_degree_low_density_count_matches_nx(self):
+
+        host = nx.fast_gnp_random_graph(10, 0.3, directed=False)
+
+        motif = nx.Graph()
+        motif.add_edge("A", "B")
+        motif.add_edge("A", "C")
+        motif.add_edge("A", "D")
+        motif.add_edge("A", "E")
+
+        self.assertEqual(
+            len(find_motifs(motif, host)),
+            len([i for i in GraphMatcher(host, motif).subgraph_monomorphisms_iter()]),
         )


### PR DESCRIPTION
No API changes. 

You don't need to specify `directed=True`; if both motif and host are directed, it's set automatically. Otherwise, the question is ill-defined and an undirected mode is used instead.