### PR TITLE
Permit falsy node IDs

### DIFF
--- a/grandiso/__init__.py
+++ b/grandiso/__init__.py
@@ -217,10 +217,10 @@ def get_next_backbone_candidates(
         # :(
         (source, _, target) = required_edges[0]
         if directed:
-            if source:
+            if source is not None:
                 # this is a "from" edge:
                 candidate_nodes = list(host.adj[backbone[source]])
-            elif target:
+            elif target is not None:
                 # this is a "from" edge:
                 candidate_nodes = list(host.pred[backbone[target]])
         else:
@@ -234,10 +234,10 @@ def get_next_backbone_candidates(
         candidate_nodes_set = set()
         for (source, _, target) in required_edges:
             if directed:
-                if source:
+                if source is not None:
                     # this is a "from" edge:
                     candidate_nodes_from_this_edge = list(host.adj[backbone[source]])
-                elif target:
+                elif target is not None:
                     # this is a "from" edge:
                     candidate_nodes_from_this_edge = list(host.pred[backbone[target]])
             else:

--- a/grandiso/test_grandiso.py
+++ b/grandiso/test_grandiso.py
@@ -175,6 +175,20 @@ class TestSubgraphMatching:
             [i for i in DiGraphMatcher(host, motif).subgraph_monomorphisms_iter()]
         )
 
+    def test_falsy_node_names(self):
+
+        motif = nx.DiGraph()
+        motif.add_edge(0, 1)
+        motif.add_edge(1, 2)
+        motif.add_edge(2, 0)
+
+        host = nx.DiGraph()
+        host.add_edge(0, 1)
+        host.add_edge(1, 2)
+        host.add_edge(2, 0)
+
+        assert len(find_motifs(motif, host)) == 3
+
 
 class TestUndirectedSubgraphMatching:
     def test_subgraph_equals_graph_triangle(self):


### PR DESCRIPTION
Previously, falsy node IDs (e.g. `""`, `0`, `False`) were interpreted as a "null" node; in other words, edges to that node were ignored. This was helpful in cases where knowing the structure of the graph was useful but the edges that terminated in the null nodes weren't useful for identifying subgraph isomorphisms.

In order to bring this package more in line with the NetworkX API, this behavior is now no longer permitted, and all nodes are treated the same.

- [x] Tests
- [x] Implementation