### PR TITLE
Dramatically improve worst-case time

### DIFF
--- a/grandiso/__init__.py
+++ b/grandiso/__init__.py
@@ -264,6 +264,7 @@ def get_next_backbone_candidates(
         {**backbone, next_node: c}
         for c in candidate_nodes
         if c not in backbone.values()
+        and is_node_structural_match(next_node, c, motif, host)
     ]
 
     # One last filtering step here. This is to catch the cases where you have

--- a/grandiso/test_grandiso.py
+++ b/grandiso/test_grandiso.py
@@ -362,3 +362,13 @@ class TestRandomGraphMonomorphisms:
             [i for i in DiGraphMatcher(host, motif).subgraph_monomorphisms_iter()]
         )
 
+
+class TestSubcliques:
+    def test_subcliques_slow(self):
+        host = nx.star_graph(30000)
+        host.add_edge(6, 9)
+
+        motif = nx.complete_graph(3)
+
+        assert find_motifs(motif, host, count_only=True) == 6
+


### PR DESCRIPTION
Some of the best characters-per-amount-of-improvement ratio I've ever written :)

In the worst-case of this algorithm (before), the worst-case is encountered when downstream nodes can't be filtered based upon connectivity to the partial candidate-mapping.

For example, in the star graph on 100 nodes, it takes us O(200) iterations to realize that we can't form any triangles: First to pick random nodes, and then to draw the first edge and realize there's nowhere for us to go.

This improvement checks the minimum degree of the receiving end of the edge, and short-circuits any search that is doomed to fail due to not-enough-places-to-go. In short, given a candidate mapping for any node, degree_motif ≥ degree_host.

---

The contrived worst-case star example is a new test in the GrandIso test-suite. Star(30K) takes nearly 30 seconds to run in the old model. In the new model, it is near-instantaneous.