### PR TITLE
Memoize nodematch function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## v1.2.0 (Unreleased)
+## v1.2.1 (Unreleased)
+
+-   Features
+    -   Memoize node match function calls, and enable the user to pass custom node match functions. This greatly improves worst-case performance by removing excess calls to the note match functions, at the cost of additional memory.
+
+## [v1.2.0 (May 4 2021)](https://pypi.org/project/grandiso/1.2.0/)
 
 -   Features
     -   Adds a `queues` submodule to enable customized queue construction behavior (breadth-first or depth-first traversal).

--- a/grandiso/__init__.py
+++ b/grandiso/__init__.py
@@ -132,7 +132,7 @@ def get_next_backbone_candidates(
         # without being an insane person, let's filter on max degree in host:
         return [
             {next_node: n}
-            for n in host.nodes()
+            for n in host.nodes
             if is_node_attr_match(next_node, n, motif, host)
             and is_node_structural_match(next_node, n, motif, host)
         ]
@@ -140,7 +140,7 @@ def get_next_backbone_candidates(
     else:
         _node_with_greatest_backbone_count: Optional[str] = None
         _greatest_backbone_count = 0
-        for motif_node_id in motif.nodes():
+        for motif_node_id in motif.nodes:
             if motif_node_id in backbone:
                 continue
             # How many connections to existing backbone?
@@ -269,7 +269,7 @@ def get_next_backbone_candidates(
             if all(
                 [
                     host.has_edge(mapping[motif_u], mapping[motif_v])
-                    for motif_u, motif_v in motif.edges()
+                    for motif_u, motif_v in motif.edges
                 ]
             ):
                 # This is a "complete" match!
@@ -308,7 +308,7 @@ def uniform_node_interestingness(motif: nx.Graph) -> dict:
     list of nodes down to a smaller set.
 
     """
-    return {n: 1 for n in motif.nodes()}
+    return {n: 1 for n in motif.nodes}
 
 
 def find_motifs_iter(


### PR DESCRIPTION
This adds a LRU-cache to the node match function calls, which greatly reduces the worst-case performance of subgraph search.