### PR TITLE
Remove profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 
-## v1.2.1 (Unreleased)
+## v2.0.0 (Unreleased)
 
 -   Features
     -   Memoize node match function calls, and enable the user to pass custom node match functions. This greatly improves worst-case performance by removing excess calls to the note match functions, at the cost of additional memory.
+-   Housekeeping
+    -   Remove the `profile` argument and profiling flow. (For profiling needs, you can now pass a profiling queue from the `queues` submodule.)
 
 ## [v1.2.0 (May 4 2021)](https://pypi.org/project/grandiso/1.2.0/)
 

--- a/docs/reference/grandiso/grandiso.md
+++ b/docs/reference/grandiso/grandiso.md
@@ -1,18 +1,108 @@
+## _Function_ `_is_node_attr_match(motif_node_id: str, host_node_id: str, motif: nx.Graph, host: nx.Graph) -> bool`
+
+Check if a node in the host graph matches the attributes in the motif.
+
+### Arguments
+
+> -   **motif_node_id** (`str`: `None`): The motif node ID
+> -   **host_node_id** (`str`: `None`): The host graph ID
+> -   **motif** (`nx.Graph`: `None`): The motif graph
+> -   **host** (`nx.Graph`: `None`): The host graph
+
+### Returns
+
+> -   **bool** (`None`: `None`): True if the host node matches the attributes in the motif
+
+## _Function_ `_is_node_structural_match(motif_node_id: str, host_node_id: str, motif: nx.Graph, host: nx.Graph) -> bool`
+
+Check if the motif node here is a valid structural match.
+
+Specifically, this requires that a host node has at least the degree as the motif node.
+
+### Arguments
+
+> -   **motif_node_id** (`str`: `None`): The motif node ID
+> -   **host_node_id** (`str`: `None`): The host graph ID
+> -   **motif** (`nx.Graph`: `None`): The motif graph
+> -   **host** (`nx.Graph`: `None`): The host graph
+
+### Returns
+
+> -   **bool** (`None`: `None`): True if the motif node maps to this host node
+
+## _Function_ `get_next_backbone_candidates(backbone: dict, motif: nx.Graph, host: nx.Graph, interestingness: dict, next_node: str = None, directed: bool = True, is_node_structural_match=_is_node_structural_match, is_node_attr_match=_is_node_attr_match, isomorphisms_only: bool = False) -> List[dict]`
+
+Get a list of candidate node assignments for the next "step" of this map.
+
+### Arguments
+
+> -   **backbone** (`dict`: `None`): Mapping of motif node IDs to one set of host graph IDs
+> -   **motif** (`Graph`: `None`): A graph representation of the motif
+> -   **host** (`Graph`: `None`): The host graph, complete
+> -   **interestingness** (`dict`: `None`): A mapping of motif node IDs to interestingness
+> -   **next_node** (`str`: `None`): Optional suggestion for the next node to assign
+> -   **directed** (`bool`: `True`): Whether host and motif are both directed
+> -   **isomorphisms_only** (`bool`: `False`): If true, only isomorphisms will be
+
+        returned (instead of all monomorphisms)
+
+### Returns
+
+> -   **List[dict]** (`None`: `None`): A new list of mappings with one additional element mapped
+
 ## _Function_ `uniform_node_interestingness(motif: nx.Graph) -> dict`
 
 Sort the nodes in a motif by their interestingness.
 
 Most interesting nodes are defined to be those that most rapidly filter the list of nodes down to a smaller set.
 
-## _Function_ `find_motifs(motif: nx.Graph, host: nx.Graph) -> List[dict]`
+## _Function_ `find_motifs_iter(motif: nx.Graph, host: nx.Graph, interestingness: dict = None, directed: bool = None, queue_=queue.SimpleQueue, isomorphisms_only: bool = False, hints: List[Dict[Hashable, Hashable]] = None, is_node_structural_match=_is_node_structural_match, is_node_attr_match=_is_node_attr_match) -> Generator[dict, None, None]`
 
-Get a list of mappings from motif node IDs to host graph IDs.
+Yield mappings from motif node IDs to host graph IDs.
 
 ### Arguments
 
-> -   **motif** (`nx.Graph`: `None`): The motif graph (needle) to search for
-> -   **host** (`nx.Graph`: `None`): The host graph (haystack) to search within
+> -   **motif** (`nx.DiGraph`: `None`): The motif graph (needle) to search for
+> -   **host** (`nx.DiGraph`: `None`): The host graph (haystack) to search within
+> -   **interestingness** (`dict`: `None`): A map of each node in `motif` to a float
+
+        number that indicates an ordinality in which to address each node
+
+> -   **directed** (`bool`: `None`): Whether direction should be considered during
+
+        search. If omitted, this will be based upon the motif directedness.
+
+> -   **queue\_** (`queue.Queue`: `None`): What kind of queue to use.
+> -   **hints** (`dict`: `None`): A dictionary of initial starting mappings. By default,
+
+        searches for all instances. You can constrain a node by passing a
+
+> -   **item** (`None`: `None`): `[{motifId: hostId}]`.
+> -   **isomorphisms_only** (`bool`: `False`): Whether to return isomorphisms (the
+
+        default is monomorphisms).
 
 ### Returns
 
+    Generator[dict, None, None]
+
+## _Function_ `find_motifs(motif: nx.Graph,host: nx.Graph,*args,count_only: bool = False,limit: int = None,is_node_attr_match=_is_node_attr_match,is_node_structural_match=_is_node_structural_match,**kwargs) -> Union[int, List[dict]]`
+
+Get a list of mappings from motif node IDs to host graph IDs.
+
+See grandiso#find_motifs_iter for full argument list.
+
+### Arguments
+
+> -   **count_only** (`bool`: `False`): If True, return only an integer count of the
+
+        number of motifs, rather than a list of mappings.
+
+> -   **limit** (`int`: `None`): A limit to place on the number of returned mappings.
+
+        The search will terminate once the limit is reached.
+
+### Returns
+
+> -   **int** (`None`: `None`): If `count_only` is True, return the length of the List.
 > -   **List[dict]** (`None`: `None`): A list of mappings from motif node IDs to host graph IDs

--- a/docs/reference/grandiso/queues.py.md
+++ b/docs/reference/grandiso/queues.py.md
@@ -1,115 +1,101 @@
-## *Class* `QueuePolicy(Enum)`
-
+## _Class_ `QueuePolicy(Enum)`
 
 An Enum for queue pop policy.
 
 DEPTHFIRST policy is identified with pushing and popping on the same side of the queue. BREADTHFIRST is identified with pushing and popping from the opposite side of the queue.
 
-
-
-## *Class* `ProfilingQueue(queue.SimpleQueue)`
-
+## _Class_ `ProfilingQueue(queue.SimpleQueue)`
 
 A simple queue to enable profiling. This queue keeps track of its size over time so that you can more easily debug performance.
 
 Note that you do not want to use this queue for production workloads, as it adds substantial overhead.
 
-
-
-## *Function* `__init__(self)`
-
+## _Function_ `__init__(self)`
 
 Create a new ProfilingQueue.
 
 ### Arguments
+
     None
 
 ### Returns
+
     None
 
-
-
-## *Function* `put(self, *args, **kwargs)`
-
+## _Function_ `put(self, *args, **kwargs)`
 
 Put a new element into the queue.
 
 ### Arguments
-> - **element** (`None`: `None`): The element to add to the queue
+
+> -   **element** (`None`: `None`): The element to add to the queue
 
 ### Returns
+
     None
 
-
-
-## *Function* `get(self, *args, **kwargs)`
-
+## _Function_ `get(self, *args, **kwargs)`
 
 Get a new item from the queue.
 
 ### Arguments
+
     None
 
 ### Returns
-> - **Any** (`None`: `None`): The element popped from the queue
 
+> -   **Any** (`None`: `None`): The element popped from the queue
 
-
-## *Class* `Deque`
-
+## _Class_ `Deque`
 
 A double-ended queue implementation.
 
-
-
-## *Function* `__init__(self, policy: QueuePolicy = QueuePolicy.DEPTHFIRST)`
-
+## _Function_ `__init__(self, policy: QueuePolicy = QueuePolicy.DEPTHFIRST)`
 
 Create a new double-ended queue.
 
 ### Arguments
-> - **policy** (`QueuePolicy`: `None`): The policy to use when adding and removing
+
+> -   **policy** (`QueuePolicy`: `None`): The policy to use when adding and removing
+
         elements from this queue. Defaults to depth-first.
 
 ### Returns
+
     None
 
-
-
-## *Function* `put(self, *args, **kwargs)`
-
+## _Function_ `put(self, *args, **kwargs)`
 
 Put a new element into the queue.
 
 ### Arguments
-> - **element** (`None`: `None`): The element to add to the queue
+
+> -   **element** (`None`: `None`): The element to add to the queue
 
 ### Returns
+
     None
 
-
-
-## *Function* `get(self, *args, **kwargs)`
-
+## _Function_ `get(self, *args, **kwargs)`
 
 Get a new item from the queue.
 
 ### Arguments
+
     None
 
 ### Returns
-> - **Any** (`None`: `None`): The element popped from the queue
 
+> -   **Any** (`None`: `None`): The element popped from the queue
 
-
-## *Function* `empty(self)`
-
+## _Function_ `empty(self)`
 
 Returns True if the queue is empty.
 
 ### Arguments
+
     None
 
 ### Returns
-> - **bool** (`None`: `None`): True if the queue has nothing more to pop
 
+> -   **bool** (`None`: `None`): True if the queue has nothing more to pop

--- a/docs/reference/grandiso/queues.py.md
+++ b/docs/reference/grandiso/queues.py.md
@@ -113,4 +113,3 @@ Returns True if the queue is empty.
 ### Returns
 > - **bool** (`None`: `None`): True if the queue has nothing more to pop
 
-

--- a/grandiso/test_grandiso.py
+++ b/grandiso/test_grandiso.py
@@ -462,9 +462,3 @@ class TestIterator:
         motif = nx.complete_graph(3)
         with pytest.raises(Exception):
             next(find_motifs_iter(motif, host, hints=[{"F": "X"}]))
-
-    def test_(self):
-        host = nx.complete_graph(8)
-        motif = nx.complete_graph(3)
-        result = next(find_motifs_iter(motif, host, profile=True))
-        assert isinstance(result, tuple)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="grandiso",
-    version="1.2.0",
+    version="2.0.0",
     author="Jordan Matelsky",
     author_email="opensource@matelsky.com",
     description="Performant subgraph isomorphism",


### PR DESCRIPTION
This PR removes support for the `profiling` option, which added additional logic flow and was no longer needed. (If you still want to profile performance using a queue, you can use the `queues.ProfilingQueue` from the `queues` submodule.)

This is a breaking change.