### PR TITLE
Python 3.6 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/grandiso/queues.py
+++ b/grandiso/queues.py
@@ -3,7 +3,10 @@ import queue
 from enum import Enum
 
 
-SimpleQueue = queue.SimpleQueue
+try:
+    SimpleQueue = queue.SimpleQueue
+except:
+    SimpleQueue = queue.Queue
 
 
 class QueuePolicy(Enum):
@@ -20,7 +23,7 @@ class QueuePolicy(Enum):
     BREADTHFIRST = 2
 
 
-class ProfilingQueue(queue.SimpleQueue):
+class ProfilingQueue(SimpleQueue):
     """
     A simple queue to enable profiling. This queue keeps track of its size over
     time so that you can more easily debug performance.
@@ -42,7 +45,7 @@ class ProfilingQueue(queue.SimpleQueue):
 
         """
         super(ProfilingQueue, self).__init__()
-        self._size_history = queue.SimpleQueue()
+        self._size_history = SimpleQueue()
         self._size = 0
 
     def put(self, *args, **kwargs):


### PR DESCRIPTION
`SimpleQueue` has been introduced in Python 3.7.
Not sure it's a goal of the project to support Python 3.6, but it seems like easy enough to achieve to be worth it.