### PR TITLE
support edge hop

### DIFF
--- a/grandiso/test_grandiso.py
+++ b/grandiso/test_grandiso.py
@@ -554,3 +554,22 @@ class TestBrokenMotifFailures:
         motif = nx.DiGraph()
         with pytest.raises(ValueError):
             find_motifs(motif, host)
+
+
+def test_edge_hopping():
+    host = nx.DiGraph()
+    host.add_edge("A", "B")
+    host.add_edge("B", "C")
+    host.add_edge("A", "D")
+
+    motif = nx.DiGraph()
+    motif.add_edge("a", "b", __min_hop__ = 0, __max_hop__ = 2)
+
+    res = list(find_motifs_iter(motif, host))
+    assert len(res) == 7
+    check = [
+        {'a': 'A', 'b': 'D'}, {'a': 'A', 'b': 'B'}, {'a': 'A', 'b': 'A'},
+        {'a': 'B', 'b': 'B'}, {'a': 'B', 'b': 'C'}, {'a': 'C', 'b': 'C'},
+        {'a': 'D', 'b': 'D'}]
+    key = lambda it: (it["a"], it["b"])
+    assert sorted(res, key=key) == sorted(check, key=key)


### PR DESCRIPTION
many tests fail, apparently, I missed something

one of the biggest changes is `candidate_nodes` now can have the current next_node if the min_hop is 0. Additionally, `get_next_backbone_candidates` now returns a list of (candidate, last_node) so that I know what is the last node. If there is a triangle in the motif, I think I'm going to miss the last edge if it has any hopping.

I feel like I'm talking more and more about edges, while the algor care more about nodes. Can you take a look and see how it can be better, @j6k4m8 ?