### PR TITLE
`find_motifs_iter`: report best match

### DIFF
--- a/grandiso/__init__.py
+++ b/grandiso/__init__.py
@@ -363,6 +363,7 @@ def find_motifs_iter(
     is_node_structural_match=_is_node_structural_match,
     is_node_attr_match=_is_node_attr_match,
     is_edge_attr_match=_is_edge_attr_match,
+    best_match=[None],
 ) -> Generator[dict, None, None]:
     """
     Yield mappings from motif node IDs to host graph IDs.
@@ -404,6 +405,10 @@ def find_motifs_iter(
 
     # Graph path traversal function
     def walk(path):
+
+        if best_match[0] is None or len(best_match[0]) < len(path):
+            best_match[0] = dict(path)
+
         if path and len(path) == len(motif):
             # Path complete
             yield path


### PR DESCRIPTION
In case of no results, it's still useful to have something to report to the user.

Our specific use case is the following: we use grandiso in our test framework (which involves graphs). In case of test failure (no graph match), we currently get no information and the developer needs to figure out on its own the problem.
With this patch, we can provide the developers with a pair of colored graphs reporting the best match we found before giving up, which usually enables the developer to rapidly highlight the problem by looking at uncolored nodes.

It's not perfect and I'm open to feedback on the metric to establish the best match and to more Pythonic ways to report the best match (currently it uses a one-element `list` as an "out" parameter).

Note the leftmost white node, it's the source of the mismatch:

<img src="https://github.com/user-attachments/assets/9ca5820f-4c31-44e2-a7e7-ac1d03770e1c" width="49%" />
<img src="https://github.com/user-attachments/assets/df76aed7-7f0a-45b2-acd3-56027a5b014d" width="49%" />
